### PR TITLE
Removed the usage of zend-servicemanager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
     },
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-math": "~2.5",
-        "zendframework/zend-stdlib": "~2.5",
-        "zendframework/zend-servicemanager": "~2.5"
+        "zendframework/zend-math": "dev-develop as 2.6.0",
+        "zendframework/zend-stdlib": "~2.7",
+        "container-interop/container-interop": "~1.0"
     },
     "suggest": {
         "ext-mcrypt": "Required for most features of Zend\\Crypt"

--- a/src/BlockCipher.php
+++ b/src/BlockCipher.php
@@ -12,6 +12,7 @@ namespace Zend\Crypt;
 use Zend\Crypt\Key\Derivation\Pbkdf2;
 use Zend\Crypt\Symmetric\SymmetricInterface;
 use Zend\Math\Rand;
+use Interop\Container\ContainerInterface;
 
 /**
  * Encrypt using a symmetric cipher then authenticate using HMAC (SHA-256)
@@ -103,7 +104,7 @@ class BlockCipher
     /**
      * Returns the symmetric cipher plugin manager.  If it doesn't exist it's created.
      *
-     * @return SymmetricPluginManager
+     * @return ContainerInterface
      */
     public static function getSymmetricPluginManager()
     {
@@ -123,18 +124,17 @@ class BlockCipher
     public static function setSymmetricPluginManager($plugins)
     {
         if (is_string($plugins)) {
-            if (!class_exists($plugins)) {
+            if (!class_exists($plugins) || ! is_subclass_of($plugins, ContainerInterface::class)) {
                 throw new Exception\InvalidArgumentException(sprintf(
-                    'Unable to locate symmetric cipher plugins using class "%s"; class does not exist',
+                    'Unable to locate symmetric cipher plugins using class "%s"; class does not exist or does not implement ContainerInterface',
                     $plugins
                 ));
             }
             $plugins = new $plugins();
         }
-        if (!$plugins instanceof SymmetricPluginManager) {
+        if (!$plugins instanceof ContainerInterface) {
             throw new Exception\InvalidArgumentException(sprintf(
-                'Expected an instance or extension of %s\SymmetricPluginManager; received "%s"',
-                __NAMESPACE__,
+                'Symmetric plugin must implements Interop\Container\ContainerInterface;; received "%s"',
                 (is_object($plugins) ? get_class($plugins) : gettype($plugins))
             ));
         }

--- a/src/BlockCipher.php
+++ b/src/BlockCipher.php
@@ -85,7 +85,7 @@ class BlockCipher
     }
 
     /**
-     * Factory.
+     * Factory
      *
      * @param  string      $adapter
      * @param  array       $options
@@ -94,7 +94,8 @@ class BlockCipher
     public static function factory($adapter, $options = [])
     {
         $plugins = static::getSymmetricPluginManager();
-        $adapter = $plugins->get($adapter, (array) $options);
+        $adapter = $plugins->get($adapter);
+        $adapter->setOptions($options);
 
         return new static($adapter);
     }

--- a/src/Symmetric/Mcrypt.php
+++ b/src/Symmetric/Mcrypt.php
@@ -25,13 +25,6 @@ class Mcrypt implements SymmetricInterface
     const DEFAULT_PADDING = 'pkcs7';
 
     /**
-     * Options
-     *
-     * @var array
-     */
-    protected $options = [];
-
-    /**
      * Key
      *
      * @var string
@@ -165,18 +158,7 @@ class Mcrypt implements SymmetricInterface
                         break;
                 }
             }
-            $this->options = $options;
         }
-    }
-
-    /**
-     * Get the Options
-     *
-     * @return array
-     */
-    public function getOptions()
-    {
-        return $this->options;
     }
 
     /**

--- a/src/Symmetric/Mcrypt.php
+++ b/src/Symmetric/Mcrypt.php
@@ -197,7 +197,7 @@ class Mcrypt implements SymmetricInterface
     /**
      * Returns the padding plugin manager.  If it doesn't exist it's created.
      *
-     * @return PaddingPluginManager
+     * @return ContainerInterface
      */
     public static function getPaddingPluginManager()
     {

--- a/src/Symmetric/PaddingPluginManager.php
+++ b/src/Symmetric/PaddingPluginManager.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Crypt\Symmetric;
 
-use Zend\ServiceManager\AbstractPluginManager;
+use Interop\Container\ContainerInterface;
 
 /**
  * Plugin manager implementation for the padding adapter instances.
@@ -18,44 +18,34 @@ use Zend\ServiceManager\AbstractPluginManager;
  * Padding\PaddingInterface. Additionally, it registers a number of default
  * padding adapters available.
  */
-class PaddingPluginManager extends AbstractPluginManager
+class PaddingPluginManager implements ContainerInterface
 {
-    /**
-     * Default set of padding adapters
-     *
-     * @var array
-     */
-    protected $invokableClasses = [
-        'pkcs7' => 'Zend\Crypt\Symmetric\Padding\Pkcs7'
+    private $paddings = [
+        'pkcs7'     => Padding\Pkcs7::class,
+        'nopadding' => Padding\NoPadding::class,
+        'null'      => Padding\NoPadding::class,
     ];
 
     /**
-     * Do not share by default
+     * Do we have the padding plugin?
      *
-     * @var bool
+     * @param  string $id
+     * @return bool
      */
-    protected $shareByDefault = false;
+    public function has($id)
+    {
+        return array_key_exists($id, $this->paddings);
+    }
 
     /**
-     * Validate the plugin
+     * Retrieve the padding plugin
      *
-     * Checks that the padding adapter loaded is an instance of Padding\PaddingInterface.
-     *
-     * @param  mixed $plugin
-     * @return void
-     * @throws Exception\InvalidArgumentException if invalid
+     * @param  string $id
+     * @return Padding\PaddingInterface
      */
-    public function validatePlugin($plugin)
+    public function get($id)
     {
-        if ($plugin instanceof Padding\PaddingInterface) {
-            // we're okay
-            return;
-        }
-
-        throw new Exception\InvalidArgumentException(sprintf(
-            'Plugin of type %s is invalid; must implement %s\Padding\PaddingInterface',
-            (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
-            __NAMESPACE__
-        ));
+        $class = $this->paddings[$id];
+        return new $class();
     }
 }

--- a/src/Symmetric/SymmetricInterface.php
+++ b/src/Symmetric/SymmetricInterface.php
@@ -26,10 +26,19 @@ interface SymmetricInterface
      */
     public function setKey($key);
 
+    /**
+     * @return string
+     */
     public function getKey();
 
+    /**
+     * @return integer
+     */
     public function getKeySize();
 
+    /**
+     * @return string
+     */
     public function getAlgorithm();
 
     /**
@@ -37,17 +46,29 @@ interface SymmetricInterface
      */
     public function setAlgorithm($algo);
 
+    /**
+     * @return array
+     */
     public function getSupportedAlgorithms();
 
     /**
-     * @param string|false $salt
+     * @param string $salt
      */
     public function setSalt($salt);
 
+    /**
+     * @return string
+     */
     public function getSalt();
 
+    /**
+     * @return integer
+     */
     public function getSaltSize();
 
+    /**
+     * @return integer
+     */
     public function getBlockSize();
 
     /**
@@ -55,7 +76,23 @@ interface SymmetricInterface
      */
     public function setMode($mode);
 
+    /**
+     * @return string
+     */
     public function getMode();
 
+    /**
+     * @return array
+     */
     public function getSupportedModes();
+
+    /**
+     * @return array
+     */
+    public function getOptions();
+
+    /**
+     * @param array $options
+     */
+    public function setOptions($options);
 }

--- a/src/Symmetric/SymmetricInterface.php
+++ b/src/Symmetric/SymmetricInterface.php
@@ -87,11 +87,6 @@ interface SymmetricInterface
     public function getSupportedModes();
 
     /**
-     * @return array
-     */
-    public function getOptions();
-
-    /**
      * @param array $options
      */
     public function setOptions($options);

--- a/src/SymmetricPluginManager.php
+++ b/src/SymmetricPluginManager.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Crypt;
 
-use Zend\ServiceManager\AbstractPluginManager;
+use Interop\Container\ContainerInterface;
 
 /**
  * Plugin manager implementation for the symmetric adapter instances.
@@ -18,45 +18,37 @@ use Zend\ServiceManager\AbstractPluginManager;
  * Symmetric\SymmetricInterface. Additionally, it registers a number of default
  * symmetric adapters available.
  */
-class SymmetricPluginManager extends AbstractPluginManager
+class SymmetricPluginManager implements ContainerInterface
 {
     /**
      * Default set of symmetric adapters
      *
      * @var array
      */
-    protected $invokableClasses = [
-        'mcrypt' => 'Zend\Crypt\Symmetric\Mcrypt',
+    protected $symmetric = [
+        'mcrypt' => Symmetric\Mcrypt::class,
     ];
 
     /**
-     * Do not share by default
+     * Do we have the symmetric plugin?
      *
-     * @var bool
+     * @param  string $id
+     * @return bool
      */
-    protected $shareByDefault = false;
+    public function has($id)
+    {
+        return array_key_exists($id, $this->symmetric);
+    }
 
     /**
-     * Validate the plugin
+     * Retrieve the symmetric plugin
      *
-     * Checks that the adapter loaded is an instance
-     * of Symmetric\SymmetricInterface.
-     *
-     * @param  mixed $plugin
-     * @return void
-     * @throws Exception\InvalidArgumentException if invalid
+     * @param  string $id
+     * @return Symmetric\SymmetricInterface
      */
-    public function validatePlugin($plugin)
+    public function get($id)
     {
-        if ($plugin instanceof Symmetric\SymmetricInterface) {
-            // we're okay
-            return;
-        }
-
-        throw new Exception\InvalidArgumentException(sprintf(
-            'Plugin of type %s is invalid; must implement %s\Symmetric\SymmetricInterface',
-            (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
-            __NAMESPACE__
-        ));
+        $class = $this->symmetric[$id];
+        return new $class();
     }
 }

--- a/test/BlockCipherTest.php
+++ b/test/BlockCipherTest.php
@@ -192,4 +192,12 @@ class BlockCipherTest extends \PHPUnit_Framework_TestCase
         $decrypted = $this->blockCipher->decrypt($encrypted);
         $this->assertFalse($decrypted);
     }
+
+    public function testSetSymmetricPluginManager()
+    {
+        $this->blockCipher->setSymmetricPluginManager(
+            $this->getMockBuilder('Interop\Container\ContainerInterface')->getMock()
+        );
+        $this->assertInstanceOf(\Interop\Container\ContainerInterface::class, $this->blockCipher->getSymmetricPluginManager());
+    }
 }

--- a/test/Symmetric/McryptTest.php
+++ b/test/Symmetric/McryptTest.php
@@ -13,6 +13,7 @@ use Zend\Crypt\Symmetric\Exception;
 use Zend\Crypt\Symmetric\Mcrypt;
 use Zend\Crypt\Symmetric\Padding\PKCS7;
 use Zend\Config\Config;
+use Zend\Crypt\Symmetric\Padding\NoPadding;
 
 /**
  * @group      Zend_Crypt
@@ -206,5 +207,32 @@ class McryptTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Zend\Crypt\Symmetric\Exception\InvalidArgumentException');
         $this->mcrypt->decrypt($this->plaintext);
+    }
+
+    public function testSetOptions()
+    {
+        $options = [
+            'algo'    => 'blowfish',
+            'mode'    =>  MCRYPT_MODE_CFB,
+            'key'     => 'test',
+            'iv'      => '12345678',
+            'padding' => 'nopadding'
+        ];
+        $this->mcrypt->setOptions($options);
+
+        $this->assertEquals($options, $this->mcrypt->getOptions());
+        $this->assertEquals($options['algo'], $this->mcrypt->getAlgorithm());
+        $this->assertEquals($options['mode'], $this->mcrypt->getMode());
+        $this->assertEquals($options['key'], $this->mcrypt->getKey());
+        $this->assertEquals($options['iv'], $this->mcrypt->getSalt());
+        $this->assertInstanceOf(NoPadding::class, $this->mcrypt->getPadding());
+    }
+
+    public function testSetPaddingPluginManager()
+    {
+        $this->mcrypt->setPaddingPluginManager(
+            $this->getMockBuilder('Interop\Container\ContainerInterface')->getMock()
+        );
+        $this->assertInstanceOf(\Interop\Container\ContainerInterface::class, $this->mcrypt->getPaddingPluginManager());
     }
 }

--- a/test/Symmetric/McryptTest.php
+++ b/test/Symmetric/McryptTest.php
@@ -11,19 +11,30 @@ namespace ZendTest\Crypt\Symmetric;
 
 use Zend\Crypt\Symmetric\Exception;
 use Zend\Crypt\Symmetric\Mcrypt;
+use Zend\Crypt\Symmetric\Padding\NoPadding;
 use Zend\Crypt\Symmetric\Padding\PKCS7;
 use Zend\Config\Config;
-use Zend\Crypt\Symmetric\Padding\NoPadding;
 
 /**
  * @group      Zend_Crypt
  */
 class McryptTest extends \PHPUnit_Framework_TestCase
 {
-    /** @var Mcrypt */
+    /**
+     * @var Mcrypt
+     */
     protected $mcrypt;
+    /**
+     * @var string
+     */
     protected $key;
+    /**
+     * @var string
+     */
     protected $salt;
+    /**
+     * @var string
+     */
     protected $plaintext;
 
     public function setUp()
@@ -220,7 +231,6 @@ class McryptTest extends \PHPUnit_Framework_TestCase
         ];
         $this->mcrypt->setOptions($options);
 
-        $this->assertEquals($options, $this->mcrypt->getOptions());
         $this->assertEquals($options['algo'], $this->mcrypt->getAlgorithm());
         $this->assertEquals($options['mode'], $this->mcrypt->getMode());
         $this->assertEquals($options['key'], $this->mcrypt->getKey());


### PR DESCRIPTION
This PR removes the usage of [zend-servicemanager](https://github.com/zendframework/zend-servicemanager) in favor of the general interface `Interop\Container\ContainerInterface` for the usage of `Zend\Crypt\SymmetricPluginManager` and `Zend\Crypt\Symmetric\PaddingPluginManager`.
