### PR TITLE
[WIP] Fixed the multibyte string in test + enable mbstring.func_overload=7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,8 @@ install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs
 
 before_script:
-  echo 'dmbstring.func_overload=7' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  
+  echo 'mbstring.func_overload=7' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+
 script:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/phpunit --coverage-clover clover.xml ; fi
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then ./vendor/bin/phpunit ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
         - DEPLOY_DOCS="$(if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then echo -n 'true' ; else echo -n 'false' ; fi)"
         - PATH="$HOME/.local/bin:$PATH"
     - php: 7
-    - php: hhvm 
+    - php: hhvm
   allow_failures:
     - php: hhvm
 
@@ -49,6 +49,9 @@ before_install:
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs
 
+before_script:
+  echo 'dmbstring.func_overload=7' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  
 script:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/phpunit --coverage-clover clover.xml ; fi
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then ./vendor/bin/phpunit ; fi

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,10 @@
     "require": {
         "php": "^5.5 || ^7.0",
         "ext-mbstring": "*",
+        "ext-mcrypt": "*",
         "zendframework/zend-math": "^2.6",
         "zendframework/zend-stdlib": "^2.7 || ^3.0",
         "container-interop/container-interop": "~1.0"
-    },
-    "suggest": {
-        "ext-mcrypt": "Required for most features of Zend\\Crypt"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
@@ -36,7 +34,6 @@
         }
     },
     "require-dev": {
-        "ext-mcrypt": "*",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     }

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         }
     },
     "require-dev": {
+        "ext-mcrypt": "*",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     }

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,12 @@
     "require": {
         "php": "^5.5 || ^7.0",
         "ext-mbstring": "*",
-        "ext-mcrypt": "*",
         "zendframework/zend-math": "^2.6",
         "zendframework/zend-stdlib": "^2.7 || ^3.0",
         "container-interop/container-interop": "~1.0"
+    },
+    "suggest": {
+        "ext-mcrypt": "Required for most features of Zend\\Crypt"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/test/BlockCipherTest.php
+++ b/test/BlockCipherTest.php
@@ -73,7 +73,7 @@ class BlockCipherTest extends TestCase
         $result = $this->blockCipher->setSalt($salt);
         $this->assertEquals($result, $this->blockCipher);
         $this->assertEquals(
-            substr($salt, 0, $this->blockCipher->getCipher()->getSaltSize()),
+            mb_substr($salt, 0, $this->blockCipher->getCipher()->getSaltSize(), '8bit'),
             $this->blockCipher->getSalt()
         );
         $this->assertEquals($salt, $this->blockCipher->getOriginalSalt());
@@ -196,7 +196,7 @@ class BlockCipherTest extends TestCase
         $encrypted = $this->blockCipher->encrypt($this->plaintext);
         $this->assertNotEmpty($encrypted);
         // tamper the encrypted data
-        $encrypted = substr($encrypted, -1);
+        $encrypted = mb_substr($encrypted, -1, null, '8bit');
         $decrypted = $this->blockCipher->decrypt($encrypted);
         $this->assertFalse($decrypted);
     }

--- a/test/FileCipherTest.php
+++ b/test/FileCipherTest.php
@@ -255,9 +255,9 @@ class FileCipherTest extends \PHPUnit_Framework_TestCase
     protected function generateTmpFile($size, $content = 'A')
     {
         $fileName = sys_get_temp_dir() . '/' . uniqid('ZF2_FileCipher_test');
-        $num = $size / strlen($content) + 1;
-        $content  = str_repeat('A', $size / strlen($content) + 1);
-        file_put_contents($fileName, substr($content, 0, $size));
+        $num = $size / mb_strlen($content, '8bit') + 1;
+        $content  = str_repeat('A', $size / mb_strlen($content, '8bit') + 1);
+        file_put_contents($fileName, mb_substr($content, 0, $size, '8bit'));
 
         return $fileName;
     }

--- a/test/Key/Derivation/Pbkdf2Test.php
+++ b/test/Key/Derivation/Pbkdf2Test.php
@@ -24,7 +24,7 @@ class Pbkdf2Test extends \PHPUnit_Framework_TestCase
     public function testCalc()
     {
         $password = Pbkdf2::calc('sha256', 'test', $this->salt, 5000, 32);
-        $this->assertEquals(32, strlen($password));
+        $this->assertEquals(32, mb_strlen($password, '8bit'));
         $this->assertEquals('JVNgHc1AeBl/S9H6Jo2tUUi838snakDBMcsNJP0+0O0=', base64_encode($password));
     }
 

--- a/test/Key/Derivation/SaltedS2kTest.php
+++ b/test/Key/Derivation/SaltedS2kTest.php
@@ -31,7 +31,7 @@ class SaltedS2kTest extends \PHPUnit_Framework_TestCase
             return;
         }
         $password = SaltedS2k::calc('sha256', 'test', $this->salt, 32);
-        $this->assertEquals(32, strlen($password));
+        $this->assertEquals(32, mb_strlen($password, '8bit'));
         $this->assertEquals('qzQISUBUSP1iqYtwe/druhdOVqluc/Y2TetdSHSbaw8=', base64_encode($password));
     }
 
@@ -54,6 +54,6 @@ class SaltedS2kTest extends \PHPUnit_Framework_TestCase
         }
         $this->setExpectedException('Zend\Crypt\Key\Derivation\Exception\InvalidArgumentException',
                                     'The salt size must be at least of 8 bytes');
-        $password = SaltedS2k::calc('sha256', 'test', substr($this->salt, -1), 32);
+        $password = SaltedS2k::calc('sha256', 'test', mb_substr($this->salt, -1, null, '8bit'), 32);
     }
 }

--- a/test/Key/Derivation/ScryptTest.php
+++ b/test/Key/Derivation/ScryptTest.php
@@ -51,8 +51,8 @@ class ScryptTest extends \PHPUnit_Framework_TestCase
         $input   = self::hex2bin(str_replace([' ', "\n"], '', $hexInput));
         $result  = $salsa20->invokeArgs($obj, [$input]);
 
-        $this->assertEquals(64, strlen($input), 'Input must be a string of 64 bytes');
-        $this->assertEquals(64, strlen($result), 'Output must be a string of 64 bytes');
+        $this->assertEquals(64, mb_strlen($input, '8bit'), 'Input must be a string of 64 bytes');
+        $this->assertEquals(64, mb_strlen($result, '8bit'), 'Output must be a string of 64 bytes');
         $this->assertEquals(str_replace([' ', "\n"], '', $hexOutput), bin2hex($result));
     }
     /**
@@ -138,7 +138,7 @@ class ScryptTest extends \PHPUnit_Framework_TestCase
                       b9 56 ce 45 da 43 aa 90 99 de 74 06 d3 a0 5e 2a';
 
         $result = Scrypt::calc('password', '', 16, 1, 1, 64);
-        $this->assertEquals(64, strlen($result));
+        $this->assertEquals(64, mb_strlen($result, '8bit'));
         $this->assertEquals(str_replace([' ', "\n"], '', $hexOutput), bin2hex($result));
     }
 
@@ -169,7 +169,7 @@ class ScryptTest extends \PHPUnit_Framework_TestCase
                 $this->setExpectedException('Zend\Crypt\Key\Derivation\Exception\InvalidArgumentException');
             }
             $result = Scrypt::calc('test', 'salt', 16, 1, 1, $size) ?: '';
-            $this->assertEquals($size, strlen($result));
+            $this->assertEquals($size, mb_strlen($result, '8bit'));
         }
     }
 
@@ -181,7 +181,7 @@ class ScryptTest extends \PHPUnit_Framework_TestCase
      */
     protected static function hex2bin($hex)
     {
-        $len    = strlen($hex);
+        $len    = mb_strlen($hex, '8bit');
         $result = '';
         for ($i = 0; $i < $len; $i += 2) {
             $result .=  chr(hexdec($hex[$i] . $hex[$i+1]));

--- a/test/Password/ApacheTest.php
+++ b/test/Password/ApacheTest.php
@@ -84,7 +84,7 @@ class ApacheTest extends \PHPUnit_Framework_TestCase
     {
         $this->apache->setFormat('crypt');
         $hash = $this->apache->create('myPassword');
-        $this->assertEquals(13, strlen($hash));
+        $this->assertEquals(13, mb_strlen($hash, '8bit'));
         $this->assertTrue($this->apache->verify('myPassword', $hash));
     }
 
@@ -99,8 +99,8 @@ class ApacheTest extends \PHPUnit_Framework_TestCase
     {
         $this->apache->setFormat('md5');
         $hash = $this->apache->create('myPassword');
-        $this->assertEquals('$apr1$', substr($hash, 0, 6));
-        $this->assertEquals(37, strlen($hash));
+        $this->assertEquals('$apr1$', mb_substr($hash, 0, 6, '8bit'));
+        $this->assertEquals(37, mb_strlen($hash, '8bit'));
         $this->assertTrue($this->apache->verify('myPassword', $hash));
     }
 
@@ -110,7 +110,7 @@ class ApacheTest extends \PHPUnit_Framework_TestCase
         $this->apache->setUserName('Enrico');
         $this->apache->setAuthName('Auth');
         $hash = $this->apache->create('myPassword');
-        $this->assertEquals(32, strlen($hash));
+        $this->assertEquals(32, mb_strlen($hash, '8bit'));
     }
 
     /**

--- a/test/Password/BcryptShaTest.php
+++ b/test/Password/BcryptShaTest.php
@@ -107,7 +107,7 @@ class BcryptShaTest extends \PHPUnit_Framework_TestCase
     {
         $password = $this->bcrypt->create('test');
         $this->assertNotEmpty($password);
-        $this->assertEquals(60, strlen($password));
+        $this->assertEquals(60, mb_strlen($password, '8bit'));
     }
 
     public function testCreateWithSalt()
@@ -120,7 +120,7 @@ class BcryptShaTest extends \PHPUnit_Framework_TestCase
     public function testVerify()
     {
         $this->assertTrue($this->bcrypt->verify($this->password, $this->bcryptPassword));
-        $this->assertFalse($this->bcrypt->verify(substr($this->password, -1), $this->bcryptPassword));
+        $this->assertFalse($this->bcrypt->verify(mb_substr($this->password, -1, null, '8bit'), $this->bcryptPassword));
     }
 
     public function testPasswordWith8bitCharacter()

--- a/test/Password/BcryptTest.php
+++ b/test/Password/BcryptTest.php
@@ -106,7 +106,7 @@ class BcryptTest extends \PHPUnit_Framework_TestCase
     {
         $password = $this->bcrypt->create('test');
         $this->assertNotEmpty($password);
-        $this->assertEquals(60, strlen($password));
+        $this->assertEquals(60, mb_strlen($password, '8bit'));
     }
 
     public function testCreateWithSalt()
@@ -119,7 +119,7 @@ class BcryptTest extends \PHPUnit_Framework_TestCase
     public function testVerify()
     {
         $this->assertTrue($this->bcrypt->verify($this->password, $this->bcryptPassword));
-        $this->assertFalse($this->bcrypt->verify(substr($this->password, -1), $this->bcryptPassword));
+        $this->assertFalse($this->bcrypt->verify(mb_substr($this->password, -1, null, '8bit'), $this->bcryptPassword));
     }
 
     public function testPasswordWith8bitCharacter()

--- a/test/Symmetric/McryptTest.php
+++ b/test/Symmetric/McryptTest.php
@@ -64,8 +64,8 @@ class McryptTest extends \PHPUnit_Framework_TestCase
         $mcrypt  = new Mcrypt($options);
         $this->assertEquals($mcrypt->getAlgorithm(), MCRYPT_BLOWFISH);
         $this->assertEquals($mcrypt->getMode(), MCRYPT_MODE_CFB);
-        $this->assertEquals($mcrypt->getKey(), substr($this->key, 0, $mcrypt->getKeySize()));
-        $this->assertEquals($mcrypt->getSalt(), substr($this->salt, 0, $mcrypt->getSaltSize()));
+        $this->assertEquals($mcrypt->getKey(), mb_substr($this->key, 0, $mcrypt->getKeySize(), '8bit'));
+        $this->assertEquals($mcrypt->getSalt(), mb_substr($this->salt, 0, $mcrypt->getSaltSize(), '8bit'));
         $this->assertInstanceOf(PKCS7::class, $mcrypt->getPadding());
     }
 
@@ -86,8 +86,8 @@ class McryptTest extends \PHPUnit_Framework_TestCase
         $mcrypt  = new Mcrypt($config);
         $this->assertEquals($mcrypt->getAlgorithm(), MCRYPT_BLOWFISH);
         $this->assertEquals($mcrypt->getMode(), MCRYPT_MODE_CFB);
-        $this->assertEquals($mcrypt->getKey(), substr($this->key, 0, $mcrypt->getKeySize()));
-        $this->assertEquals($mcrypt->getSalt(), substr($this->salt, 0, $mcrypt->getSaltSize()));
+        $this->assertEquals($mcrypt->getKey(), mb_substr($this->key, 0, $mcrypt->getKeySize(), '8bit'));
+        $this->assertEquals($mcrypt->getSalt(), mb_substr($this->salt, 0, $mcrypt->getSaltSize(), '8bit'));
         $this->assertInstanceOf(PKCS7::class, $mcrypt->getPadding());
     }
 
@@ -156,7 +156,7 @@ class McryptTest extends \PHPUnit_Framework_TestCase
     {
         $this->mcrypt->setSalt($this->salt);
         $this->assertEquals(
-            substr($this->salt, 0, $this->mcrypt->getSaltSize()),
+            mb_substr($this->salt, 0, $this->mcrypt->getSaltSize(), '8bit'),
             $this->mcrypt->getSalt()
         );
         $this->assertEquals($this->salt, $this->mcrypt->getOriginalSalt());


### PR DESCRIPTION
This PR should fixes the #23 issue. Instead of writing specific unit tests for all the multibyte functions used in the code, we can execute PHP using this ini setting: **mbstring.func_overload=7**. This will execute the PHP code overloading the string functions with multibyte support. Read [here](http://php.net/manual/en/mbstring.overload.php) for more information.
