### PR TITLE
Added a benchmark for the bcrypt cost parameter + fixed a unit test

### DIFF
--- a/src/Password/Bcrypt.php
+++ b/src/Password/Bcrypt.php
@@ -155,4 +155,25 @@ class Bcrypt implements PasswordInterface
 
         return $this->salt;
     }
+
+    /**
+     * Benchmark the bcrypt hash generation to determine the cost parameter
+     * based on time to target. The default time to test is 50 milliseconds
+     * which is a good baseline for systems handling interactive logins.
+     * If you increase the time you will get high cost with better security but
+     * you need to be careful because you can expose your system to DoS attacks.
+     *
+     * @see php.net/manual/en/function.password-hash.php#refsect1-function.password-hash-examples
+     */
+    public function benchmarkCost($timeTarget = 0.05)
+    {
+        $cost = 8;
+        do {
+            $cost++;
+            $start = microtime(true);
+            password_hash("test", PASSWORD_BCRYPT, [ 'cost' => $cost ]);
+            $end = microtime(true);
+        } while (($end - $start) < $timeTarget);
+        return $cost;
+    }
 }

--- a/test/Password/BcryptTest.php
+++ b/test/Password/BcryptTest.php
@@ -116,4 +116,11 @@ class BcryptTest extends \PHPUnit_Framework_TestCase
     {
         $salt = $this->bcrypt->getSalt();
     }
+
+    public function testBenchmarkCost()
+    {
+        $cost = $this->bcrypt->benchmarkCost();
+        $this->assertInternalType("int", $cost);
+        $this->assertTrue($cost > 8 && $cost < 40);
+    }
 }

--- a/test/Password/BcryptTest.php
+++ b/test/Password/BcryptTest.php
@@ -121,6 +121,6 @@ class BcryptTest extends \PHPUnit_Framework_TestCase
     {
         $cost = $this->bcrypt->benchmarkCost();
         $this->assertInternalType("int", $cost);
-        $this->assertTrue($cost > 8 && $cost < 40);
+        $this->assertTrue($cost > 8 && $cost < 32);
     }
 }

--- a/test/SymmetricPluginManagerTest.php
+++ b/test/SymmetricPluginManagerTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Crypt;
 use Interop\Container\ContainerInterface;
 use Zend\Crypt\SymmetricPluginManager;
 use Zend\Crypt\Symmetric\SymmetricInterface;
+use Zend\Crypt\Symmetric\Exception;
 
 class SymmetricPluginManagerTest extends \PHPUnit_Framework_TestCase
 {
@@ -44,6 +45,9 @@ class SymmetricPluginManagerTest extends \PHPUnit_Framework_TestCase
     public function testGet($symmetric)
     {
         $plugin = new SymmetricPluginManager();
+        if (! extension_loaded($symmetric)) {
+            $this->setExpectedException(Exception\RuntimeException::class);
+        }
         $this->assertInstanceof(SymmetricInterface::class, $plugin->get($symmetric));
     }
 

--- a/test/SymmetricPluginManagerTest.php
+++ b/test/SymmetricPluginManagerTest.php
@@ -44,10 +44,10 @@ class SymmetricPluginManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGet($symmetric)
     {
-        $plugin = new SymmetricPluginManager();
         if (! extension_loaded($symmetric)) {
             $this->setExpectedException(Exception\RuntimeException::class);
         }
+        $plugin = new SymmetricPluginManager();
         $this->assertInstanceof(SymmetricInterface::class, $plugin->get($symmetric));
     }
 


### PR DESCRIPTION
This PR adds a benchmark function in `Zend\Crypt\Password\Bcrypt` to test the cost parameter on a time to target. This function can be used to choose the bcrypt cost parameter to use in your environment.

The default time to target is 0.05 seconds (50 milliseconds) that is which is a good baseline for systems handling interactive logins. On my environment: CPU Intel i5-2500 at 3.30GHz, 8 GB RAM, the result of the benchmark is cost 10 (the default value of `Zend\Crypt\Password\Bcrypt` and PHP).

**Note:** this function uses the same code reported in [example 4 of password_hash()](http://php.net/manual/en/function.password-hash.php#refsect1-function.password-hash-examples) in the PHP online manual.
