### PR TITLE
Add consistency to method chaining DocBlocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 - Nothing.
 
-## 3.1.1 - TBD
+## 3.2.0 - TBD
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,24 @@ All notable changes to this project will be documented in this file, in reverse 
 
 - Nothing.
 
+## 3.1.1 - TBD
+
+### Added
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 3.1.0 - 2016-08-11
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev",
-            "dev-develop": "3.1-dev"
+            "dev-master": "3.1-dev",
+            "dev-develop": "3.2-dev"
         }
     }
 }

--- a/src/BlockCipher.php
+++ b/src/BlockCipher.php
@@ -153,7 +153,7 @@ class BlockCipher
      * Set the symmetric cipher
      *
      * @param  SymmetricInterface $cipher
-     * @return BlockCipher
+     * @return BlockCipher Provides a fluent interface
      */
     public function setCipher(SymmetricInterface $cipher)
     {
@@ -175,7 +175,7 @@ class BlockCipher
      * Set the number of iterations for Pbkdf2
      *
      * @param  int $num
-     * @return BlockCipher
+     * @return BlockCipher Provides a fluent interface
      */
     public function setKeyIteration($num)
     {
@@ -198,7 +198,7 @@ class BlockCipher
      * Set the salt (IV)
      *
      * @param  string $salt
-     * @return BlockCipher
+     * @return BlockCipher Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setSalt($salt)
@@ -237,7 +237,7 @@ class BlockCipher
      * Enable/disable the binary output
      *
      * @param  bool $value
-     * @return BlockCipher
+     * @return BlockCipher Provides a fluent interface
      */
     public function setBinaryOutput($value)
     {
@@ -259,8 +259,8 @@ class BlockCipher
     /**
      * Set the encryption/decryption key
      *
-     * @param  string                             $key
-     * @return BlockCipher
+     * @param  string $key
+     * @return BlockCipher Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setKey($key)
@@ -287,7 +287,7 @@ class BlockCipher
      * Set algorithm of the symmetric cipher
      *
      * @param  string $algo
-     * @return BlockCipher
+     * @return BlockCipher Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setCipherAlgorithm($algo)
@@ -336,7 +336,7 @@ class BlockCipher
      * Set the hash algorithm for HMAC authentication
      *
      * @param  string $hash
-     * @return BlockCipher
+     * @return BlockCipher Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setHashAlgorithm($hash)
@@ -365,7 +365,7 @@ class BlockCipher
      * Set the hash algorithm for the Pbkdf2
      *
      * @param  string $hash
-     * @return BlockCipher
+     * @return BlockCipher Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setPbkdf2HashAlgorithm($hash)

--- a/src/Password/Apache.php
+++ b/src/Password/Apache.php
@@ -161,7 +161,7 @@ class Apache implements PasswordInterface
      *
      * @param  string $format
      * @throws Exception\InvalidArgumentException
-     * @return Apache
+     * @return Apache Provides a fluent interface
      */
     public function setFormat($format)
     {
@@ -192,7 +192,7 @@ class Apache implements PasswordInterface
      * Set the AuthName (for digest authentication)
      *
      * @param  string $name
-     * @return Apache
+     * @return Apache Provides a fluent interface
      */
     public function setAuthName($name)
     {
@@ -215,7 +215,7 @@ class Apache implements PasswordInterface
      * Set the username
      *
      * @param  string $name
-     * @return Apache
+     * @return Apache Provides a fluent interface
      */
     public function setUserName($name)
     {

--- a/src/Password/Bcrypt.php
+++ b/src/Password/Bcrypt.php
@@ -93,7 +93,7 @@ class Bcrypt implements PasswordInterface
      *
      * @param  int|string $cost
      * @throws Exception\InvalidArgumentException
-     * @return Bcrypt
+     * @return Bcrypt Provides a fluent interface
      */
     public function setCost($cost)
     {
@@ -124,7 +124,7 @@ class Bcrypt implements PasswordInterface
      *
      * @param  string $salt
      * @throws Exception\InvalidArgumentException
-     * @return Bcrypt
+     * @return Bcrypt Provides a fluent interface
      */
     public function setSalt($salt)
     {

--- a/src/PublicKey/DiffieHellman.php
+++ b/src/PublicKey/DiffieHellman.php
@@ -123,7 +123,7 @@ class DiffieHellman
      * Generate own public key. If a private number has not already been set,
      * one will be generated at this stage.
      *
-     * @return DiffieHellman
+     * @return DiffieHellman Provides a fluent interface
      * @throws \Zend\Crypt\Exception\RuntimeException
      */
     public function generateKeys()
@@ -174,7 +174,7 @@ class DiffieHellman
      *
      * @param string $number
      * @param string $format
-     * @return DiffieHellman
+     * @return DiffieHellman Provides a fluent interface
      * @throws \Zend\Crypt\Exception\InvalidArgumentException
      */
     public function setPublicKey($number, $format = self::FORMAT_NUMBER)
@@ -273,7 +273,7 @@ class DiffieHellman
      * Setter for the value of the prime number
      *
      * @param string $number
-     * @return DiffieHellman
+     * @return DiffieHellman Provides a fluent interface
      * @throws \Zend\Crypt\Exception\InvalidArgumentException
      */
     public function setPrime($number)
@@ -309,7 +309,7 @@ class DiffieHellman
      * Setter for the value of the generator number
      *
      * @param string $number
-     * @return DiffieHellman
+     * @return DiffieHellman Provides a fluent interface
      * @throws \Zend\Crypt\Exception\InvalidArgumentException
      */
     public function setGenerator($number)
@@ -345,7 +345,7 @@ class DiffieHellman
      *
      * @param string $number
      * @param string $format
-     * @return DiffieHellman
+     * @return DiffieHellman Provides a fluent interface
      * @throws \Zend\Crypt\Exception\InvalidArgumentException
      */
     public function setPrivateKey($number, $format = self::FORMAT_NUMBER)

--- a/src/PublicKey/Rsa.php
+++ b/src/PublicKey/Rsa.php
@@ -116,7 +116,7 @@ class Rsa
      * Set options
      *
      * @param RsaOptions $options
-     * @return Rsa
+     * @return Rsa Provides a fluent interface
      */
     public function setOptions(RsaOptions $options)
     {
@@ -332,7 +332,7 @@ class Rsa
      * @see RsaOptions::generateKeys()
      *
      * @param  array $opensslConfig
-     * @return Rsa
+     * @return Rsa Provides a fluent interface
      * @throws Rsa\Exception\RuntimeException
      */
     public function generateKeys(array $opensslConfig = [])

--- a/src/PublicKey/RsaOptions.php
+++ b/src/PublicKey/RsaOptions.php
@@ -62,7 +62,7 @@ class RsaOptions extends AbstractOptions
      * Set private key
      *
      * @param  Rsa\PrivateKey $key
-     * @return RsaOptions
+     * @return RsaOptions Provides a fluent interface
      */
     public function setPrivateKey(Rsa\PrivateKey $key)
     {
@@ -85,7 +85,7 @@ class RsaOptions extends AbstractOptions
      * Set public key
      *
      * @param  Rsa\PublicKey $key
-     * @return RsaOptions
+     * @return RsaOptions Provides a fluent interface
      */
     public function setPublicKey(Rsa\PublicKey $key)
     {
@@ -107,7 +107,7 @@ class RsaOptions extends AbstractOptions
      * Set pass phrase
      *
      * @param string $phrase
-     * @return RsaOptions
+     * @return RsaOptions Provides a fluent interface
      */
     public function setPassPhrase($phrase)
     {
@@ -129,7 +129,7 @@ class RsaOptions extends AbstractOptions
      * Set hash algorithm
      *
      * @param  string $hash
-     * @return RsaOptions
+     * @return RsaOptions Provides a fluent interface
      * @throws Rsa\Exception\RuntimeException
      * @throws Rsa\Exception\InvalidArgumentException
      */
@@ -169,7 +169,7 @@ class RsaOptions extends AbstractOptions
      * Enable/disable the binary output
      *
      * @param  bool $value
-     * @return RsaOptions
+     * @return RsaOptions Provides a fluent interface
      */
     public function setBinaryOutput($value)
     {
@@ -201,7 +201,7 @@ class RsaOptions extends AbstractOptions
      * Set the OPENSSL padding
      *
      * @param int|null $opensslPadding
-     * @return $this
+     * @return RsaOptions Provides a fluent interface
      */
     public function setOpensslPadding($opensslPadding)
     {
@@ -213,7 +213,7 @@ class RsaOptions extends AbstractOptions
      * Generate new private/public key pair
      *
      * @param  array $opensslConfig
-     * @return RsaOptions
+     * @return RsaOptions Provides a fluent interface
      * @throws Rsa\Exception\RuntimeException
      */
     public function generateKeys(array $opensslConfig = [])

--- a/src/Symmetric/Mcrypt.php
+++ b/src/Symmetric/Mcrypt.php
@@ -233,9 +233,9 @@ class Mcrypt implements SymmetricInterface
      * Set the encryption key
      * If the key is longer than maximum supported, it will be truncated by getKey().
      *
-     * @param  string                             $key
+     * @param  string $key
+     * @return Mcrypt Provides a fluent interface
      * @throws Exception\InvalidArgumentException
-     * @return Mcrypt
      */
     public function setKey($key)
     {
@@ -280,9 +280,9 @@ class Mcrypt implements SymmetricInterface
     /**
      * Set the encryption algorithm (cipher)
      *
-     * @param  string                             $algo
+     * @param  string $algo
+     * @return Mcrypt Provides a fluent interface
      * @throws Exception\InvalidArgumentException
-     * @return Mcrypt
      */
     public function setAlgorithm($algo)
     {
@@ -312,7 +312,7 @@ class Mcrypt implements SymmetricInterface
      * Set the padding object
      *
      * @param  Padding\PaddingInterface $padding
-     * @return Mcrypt
+     * @return Mcrypt Provides a fluent interface
      */
     public function setPadding(Padding\PaddingInterface $padding)
     {
@@ -422,9 +422,9 @@ class Mcrypt implements SymmetricInterface
     /**
      * Set the salt (IV)
      *
-     * @param  string                             $salt
+     * @param  string $salt
+     * @return Mcrypt Provides a fluent interface
      * @throws Exception\InvalidArgumentException
-     * @return Mcrypt
      */
     public function setSalt($salt)
     {
@@ -475,9 +475,9 @@ class Mcrypt implements SymmetricInterface
     /**
      * Set the cipher mode
      *
-     * @param  string                             $mode
+     * @param  string $mode
+     * @return Mcrypt Provides a fluent interface
      * @throws Exception\InvalidArgumentException
-     * @return Mcrypt
      */
     public function setMode($mode)
     {

--- a/src/Symmetric/Openssl.php
+++ b/src/Symmetric/Openssl.php
@@ -284,8 +284,8 @@ class Openssl implements SymmetricInterface
      * If the key is longer than maximum supported, it will be truncated by getKey().
      *
      * @param  string $key
+     * @return Openssl Provides a fluent interface
      * @throws Exception\InvalidArgumentException
-     * @return self
      */
     public function setKey($key)
     {
@@ -323,8 +323,8 @@ class Openssl implements SymmetricInterface
      * Set the encryption algorithm (cipher)
      *
      * @param  string $algo
+     * @return Openssl Provides a fluent interface
      * @throws Exception\InvalidArgumentException
-     * @return self
      */
     public function setAlgorithm($algo)
     {
@@ -353,7 +353,7 @@ class Openssl implements SymmetricInterface
      * Set the padding object
      *
      * @param  Padding\PaddingInterface $padding
-     * @return self
+     * @return Openssl Provides a fluent interface
      */
     public function setPadding(Padding\PaddingInterface $padding)
     {
@@ -503,8 +503,8 @@ class Openssl implements SymmetricInterface
      * Set the salt (IV)
      *
      * @param  string $salt
+     * @return Openssl Provides a fluent interface
      * @throws Exception\InvalidArgumentException
-     * @return self
      */
     public function setSalt($salt)
     {
@@ -566,8 +566,8 @@ class Openssl implements SymmetricInterface
      * Set the cipher mode
      *
      * @param  string $mode
+     * @return Openssl Provides a fluent interface
      * @throws Exception\InvalidArgumentException
-     * @return self
      */
     public function setMode($mode)
     {


### PR DESCRIPTION
As discussed in [fluent interface return type vs return self #7193](https://github.com/zendframework/zendframework/issues/7193), this changes remove occurrences of class names and self keyword from the DocBlocks
