### PR TITLE
GCM and CCM encryption modes for PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,13 +47,22 @@ matrix:
     - php: 7
       env:
         - DEPS=latest
-    - php: hhvm 
+    - php: 7.1
       env:
         - DEPS=lowest
-    - php: hhvm 
+    - php: 7.1
       env:
         - DEPS=locked
-    - php: hhvm 
+    - php: 7.1
+      env:
+        - DEPS=latest
+    - php: hhvm
+      env:
+        - DEPS=lowest
+    - php: hhvm
+      env:
+        - DEPS=locked
+    - php: hhvm
       env:
         - DEPS=latest
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ matrix:
     - php: 5.6
       env:
         - DEPS=locked
-        - TEST_COVERAGE=true
         - DEPLOY_DOCS="$(if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then echo -n 'true' ; else echo -n 'false' ; fi)"
         - PATH="$HOME/.local/bin:$PATH"
     - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ matrix:
     - php: 7.1
       env:
         - DEPS=locked
+        - TEST_COVERAGE=true
     - php: 7.1
       env:
         - DEPS=latest

--- a/doc/book/block-cipher.md
+++ b/doc/book/block-cipher.md
@@ -116,7 +116,7 @@ For more information on the usage of this encryption modes in PHP we suggest to
 read [this blog post](http://www.zimuel.it/authenticated-encrypt-with-openssl-and-php-7-1/).
 
 If you want to use the GCM or CCM mode with `BlockCipher` you can just specify
-the mode in the factory. For instance, here is reported an example that uses
+the mode in the factory. For instance, the following is an example of
 `aes-256-gcm` encryption with OpenSSL:
 
 ```php
@@ -131,7 +131,7 @@ $blockCipher = BlockCipher::factory(
 );
 ```
 
-And here is repoted the factory for `aes-256-ccm` algorithm:
+And below is an example demonstrating the factory for `aes-256-ccm` algorithm:
 
 ```php
 use Zend\Crypt\BlockCipher;
@@ -147,5 +147,5 @@ $blockCipher = BlockCipher::factory(
 
 > ## Recommendation
 >
-> **GCM mode is about 3x faster than CCM**, we suggest to use it if you do not
-> have specific requirements.
+> **GCM mode is about 3x faster than CCM**, we recommend using GCM unless
+> you have requirements that dictate CCM.

--- a/doc/book/block-cipher.md
+++ b/doc/book/block-cipher.md
@@ -20,11 +20,11 @@ hash function).
 > The Mcrypt extension is based on the libmcrypt library. Unfortunately, at the
 > time of writing, the project is dead, having been unmaintained for around 8
 > years, with the last release (version 2.5.8) having occurred in February 2007.
-> 
+>
 > Starting with PHP 7.1, the Mcrypt extension will be
 > [considered deprecated](https://wiki.php.net/rfc/mcrypt-viking-funeral).
 > For these reasons, **we strongly suggest using only the Openssl adapter**.
-> 
+>
 > Starting with zend-crypt 3.0, the Openssl adapter is the default (for example,
 > by `Zend\Crypt\FileCipher`), and all examples now only demonstrate that
 > adapter.
@@ -96,10 +96,56 @@ For instance, we can rewrite the previous example as follows:
 
 ```php
 use Zend\Crypt\BlockCipher;
-use Zend\Crypt\Symmetric\Mcrypt;
+use Zend\Crypt\Symmetric\Openssl;
 
-$blockCipher = new BlockCipher(new Mcrypt(['algo' => 'aes']));
+$blockCipher = new BlockCipher(new Openssl(['algo' => 'aes']));
 $blockCipher->setKey('encryption key');
 $result = $blockCipher->encrypt('this is a secret message');
 echo "Encrypted text: $result \n";
 ```
+
+## Using GCM or CCM mode from PHP 7.1+
+
+If you are using PHP 7.1+ you can choose the GCM or CCM mode for authenticated
+encryption with OpenSSL. These modes provide authenticated encryption by itself,
+without the usage of HMAC as described in the previous section.
+
+GCM is [Galois/Counter Mode](https://en.wikipedia.org/wiki/Galois/Counter_Mode)
+and CCM is [Counter with CBC-MAC](https://en.wikipedia.org/wiki/CCM_mode).
+For more information on the usage of this encryption modes in PHP we suggest to
+read [this blog post](http://www.zimuel.it/authenticated-encrypt-with-openssl-and-php-7-1/).
+
+If you want to use the GCM or CCM mode with `BlockCipher` you can just specify
+the mode in the factory. For instance, here is reported an example that uses
+`aes-256-gcm` encryption with OpenSSL:
+
+```php
+use Zend\Crypt\BlockCipher;
+
+$blockCipher = BlockCipher::factory(
+    'openssl',
+    [
+        'algo' => 'aes',
+        'mode' => 'gcm'
+    ]
+);
+```
+
+And here is repoted the factory for `aes-256-ccm` algorithm:
+
+```php
+use Zend\Crypt\BlockCipher;
+
+$blockCipher = BlockCipher::factory(
+    'openssl',
+    [
+        'algo' => 'aes',
+        'mode' => 'ccm'
+    ]
+);
+```
+
+> ## Recommendation
+>
+> **GCM mode is about 3x faster than CCM**, we suggest to use it if you do not
+> have specific requirements.

--- a/src/BlockCipher.php
+++ b/src/BlockCipher.php
@@ -292,9 +292,6 @@ class BlockCipher
      */
     public function setCipherAlgorithm($algo)
     {
-        if (empty($this->cipher)) {
-            throw new Exception\InvalidArgumentException('No symmetric cipher specified');
-        }
         try {
             $this->cipher->setAlgorithm($algo);
         } catch (Symmetric\Exception\InvalidArgumentException $e) {
@@ -311,11 +308,7 @@ class BlockCipher
      */
     public function getCipherAlgorithm()
     {
-        if (!empty($this->cipher)) {
-            return $this->cipher->getAlgorithm();
-        }
-
-        return false;
+        return $this->cipher->getAlgorithm();
     }
 
     /**
@@ -325,11 +318,7 @@ class BlockCipher
      */
     public function getCipherSupportedAlgorithms()
     {
-        if (!empty($this->cipher)) {
-            return $this->cipher->getSupportedAlgorithms();
-        }
-
-        return [];
+        return $this->cipher->getSupportedAlgorithms();
     }
 
     /**
@@ -413,9 +402,6 @@ class BlockCipher
             $data = (string) $data;
         }
 
-        if (empty($this->cipher)) {
-            throw new Exception\InvalidArgumentException('No symmetric cipher specified');
-        }
         if (empty($this->key)) {
             throw new Exception\InvalidArgumentException('No key specified for the encryption');
         }
@@ -477,9 +463,7 @@ class BlockCipher
         if (empty($this->key)) {
             throw new Exception\InvalidArgumentException('No key specified for the decryption');
         }
-        if (empty($this->cipher)) {
-            throw new Exception\InvalidArgumentException('No symmetric cipher specified');
-        }
+
         $keySize = $this->cipher->getKeySize();
         // CCM and GCM modes do not need HMAC
         if (in_array($this->cipher->getMode(), [ 'ccm', 'gcm' ])) {

--- a/src/PublicKey/DiffieHellman.php
+++ b/src/PublicKey/DiffieHellman.php
@@ -133,7 +133,9 @@ class DiffieHellman
                 'p' => $this->convert($this->getPrime(), self::FORMAT_NUMBER, self::FORMAT_BINARY),
                 'g' => $this->convert($this->getGenerator(), self::FORMAT_NUMBER, self::FORMAT_BINARY)
             ];
-            if ($this->hasPrivateKey()) {
+            // the priv_key parameter is allowed only for PHP < 7.1
+            // @see https://bugs.php.net/bug.php?id=73478
+            if ($this->hasPrivateKey() && PHP_VERSION_ID < 70100) {
                 $details['priv_key'] = $this->convert(
                     $this->privateKey,
                     self::FORMAT_NUMBER,

--- a/src/Symmetric/Mcrypt.php
+++ b/src/Symmetric/Mcrypt.php
@@ -112,8 +112,8 @@ class Mcrypt implements SymmetricInterface
     {
         if (PHP_VERSION_ID >= 70100) {
             trigger_error(
-                'The Mcrypt extension is deprecated from PHP 7.1+. ' .
-                'We suggest to use Zend\Crypt\Symmetric\Openssl.',
+                'The Mcrypt extension is deprecated from PHP 7.1+. '
+                . 'We suggest to use Zend\Crypt\Symmetric\Openssl.',
                 E_USER_DEPRECATED
             );
         }

--- a/src/Symmetric/Mcrypt.php
+++ b/src/Symmetric/Mcrypt.php
@@ -110,7 +110,14 @@ class Mcrypt implements SymmetricInterface
      */
     public function __construct($options = [])
     {
-        if (!extension_loaded('mcrypt')) {
+        if (PHP_VERSION_ID >= 70100) {
+            trigger_error(
+                'The Mcrypt extension is deprecated from PHP 7.1+. ' .
+                'We suggest to use Zend\Crypt\Symmetric\Openssl.',
+                E_USER_DEPRECATED
+            );
+        }
+        if (! extension_loaded('mcrypt')) {
             throw new Exception\RuntimeException(sprintf(
                 'You cannot use %s without the Mcrypt extension',
                 __CLASS__

--- a/src/Symmetric/Openssl.php
+++ b/src/Symmetric/Openssl.php
@@ -165,8 +165,7 @@ class Openssl implements SymmetricInterface
         }
         // Add the GCM and CCM modes for PHP 7.1+
         if (PHP_VERSION_ID >= 70100) {
-            $this->encryptionModes[] = 'gcm';
-            $this->encryptionModes[] = 'ccm';
+            array_push($this->encryptionModes, 'gcm', 'ccm');
         }
         $this->setOptions($options);
         $this->setDefaultOptions($options);
@@ -411,7 +410,7 @@ class Openssl implements SymmetricInterface
         }
         if ($this->getMode() !== 'gcm' && $this->getMode() !== 'ccm') {
             throw new Exception\RuntimeException(
-                'You can set the Tag Size only for CCM or GCM mode'
+                'You can set Additional Authentication Data (AAD) only for CCM or GCM mode'
             );
         }
         $this->aad = $aad;

--- a/test/BlockCipher/AbstractBlockCipherTest.php
+++ b/test/BlockCipher/AbstractBlockCipherTest.php
@@ -50,6 +50,14 @@ abstract class AbstractBlockCipherTest extends TestCase
         $this->assertEquals('test', $this->blockCipher->getKey());
     }
 
+    /**
+     * @expectedException Zend\Crypt\Exception\InvalidArgumentException
+     */
+    public function testSetEmptyKey()
+    {
+        $result = $this->blockCipher->setKey('');
+    }
+
     public function testSetSalt()
     {
         $salt = str_repeat('a', $this->blockCipher->getCipher()->getSaltSize() + 2);
@@ -60,6 +68,14 @@ abstract class AbstractBlockCipherTest extends TestCase
             $this->blockCipher->getSalt()
         );
         $this->assertEquals($salt, $this->blockCipher->getOriginalSalt());
+    }
+
+    /**
+     * @expectedException Zend\Crypt\Exception\InvalidArgumentException
+     */
+    public function testSetWrongSalt()
+    {
+        $this->blockCipher->setSalt('x');
     }
 
     public function testSetAlgorithm()
@@ -85,11 +101,27 @@ abstract class AbstractBlockCipherTest extends TestCase
         $this->assertEquals('sha1', $this->blockCipher->getHashAlgorithm());
     }
 
+    /**
+     * @expectedException Zend\Crypt\Exception\InvalidArgumentException
+     */
+    public function testSetUnsupportedHashAlgorithm()
+    {
+        $result = $this->blockCipher->setHashAlgorithm('foo');
+    }
+
     public function testSetPbkdf2HashAlgorithm()
     {
         $result = $this->blockCipher->setPbkdf2HashAlgorithm('sha1');
         $this->assertEquals($result, $this->blockCipher);
         $this->assertEquals('sha1', $this->blockCipher->getPbkdf2HashAlgorithm());
+    }
+
+    /**
+     * @expectedException Zend\Crypt\Exception\InvalidArgumentException
+     */
+    public function testSetUnsupportedPbkdf2HashAlgorithm()
+    {
+        $result = $this->blockCipher->setPbkdf2HashAlgorithm('foo');
     }
 
     public function testSetKeyIteration()
@@ -137,6 +169,8 @@ abstract class AbstractBlockCipherTest extends TestCase
         $this->blockCipher->setKey('test');
         $this->blockCipher->setKeyIteration(1000);
         $this->blockCipher->setBinaryOutput(true);
+        $this->assertTrue($this->blockCipher->getBinaryOutput());
+
         foreach ($this->blockCipher->getCipherSupportedAlgorithms() as $algo) {
             $this->blockCipher->setCipherAlgorithm($algo);
             $encrypted = $this->blockCipher->encrypt($this->plaintext);
@@ -172,6 +206,30 @@ abstract class AbstractBlockCipherTest extends TestCase
         }
     }
 
+    /**
+     * @expectedException Zend\Crypt\Exception\InvalidArgumentException
+     */
+    public function testDecryptNotString()
+    {
+        $this->blockCipher->decrypt([ 'foo' ]);
+    }
+
+    /**
+     * @expectedException Zend\Crypt\Exception\InvalidArgumentException
+     */
+    public function testDecryptEmptyString()
+    {
+        $this->blockCipher->decrypt('');
+    }
+
+    /**
+     * @expectedException Zend\Crypt\Exception\InvalidArgumentException
+     */
+    public function testDecyptWihoutKey()
+    {
+        $this->blockCipher->decrypt('encrypted data');
+    }
+
     public function testDecryptAuthFail()
     {
         $this->blockCipher->setKey('test');
@@ -194,5 +252,33 @@ abstract class AbstractBlockCipherTest extends TestCase
         $this->assertInstanceOf(ContainerInterface::class, $this->blockCipher->getSymmetricPluginManager());
 
         $this->blockCipher->setSymmetricPluginManager($old);
+    }
+
+    /**
+     * @expectedException Zend\Crypt\Exception\RuntimeException
+     */
+    public function testFactoryWithWrongAdapter()
+    {
+        $this->blockCipher = BlockCipher::factory('foo');
+    }
+
+    /**
+     * @expectedException Zend\Crypt\Exception\InvalidArgumentException
+     */
+    public function testSetWrongSymmetricPluginManager()
+    {
+        $this->blockCipher->setSymmetricPluginManager(
+            stdClass::class
+        );
+    }
+
+    /**
+     * @expectedException Zend\Crypt\Exception\InvalidArgumentException
+     */
+    public function testSetNotExistingSymmetricPluginManager()
+    {
+        $this->blockCipher->setSymmetricPluginManager(
+            'Foo'
+        );
     }
 }

--- a/test/BlockCipher/CompatibilityTest.php
+++ b/test/BlockCipher/CompatibilityTest.php
@@ -15,6 +15,13 @@ use Zend\Math\Rand;
 
 class CompatibilityTest extends TestCase
 {
+    public function setUp()
+    {
+        if (PHP_VERSION_ID >= 70100) {
+            $this->markTestSkipped('The Mcrypt tests are deprecated for PHP 7.1+');
+        }
+    }
+
     public function getAlgos()
     {
         return [

--- a/test/BlockCipher/McryptTest.php
+++ b/test/BlockCipher/McryptTest.php
@@ -12,8 +12,12 @@ use Zend\Crypt\BlockCipher;
 
 class MCryptTest extends AbstractBlockCipherTest
 {
+
     public function setUp()
     {
+        if (PHP_VERSION_ID >= 70100) {
+            $this->markTestSkipped('The Mcrypt tests are deprecated for PHP 7.1+');
+        }
         try {
             $this->cipher = new Symmetric\Mcrypt([
                 'algorithm' => 'aes',

--- a/test/BlockCipher/McryptTest.php
+++ b/test/BlockCipher/McryptTest.php
@@ -12,7 +12,6 @@ use Zend\Crypt\BlockCipher;
 
 class MCryptTest extends AbstractBlockCipherTest
 {
-
     public function setUp()
     {
         if (PHP_VERSION_ID >= 70100) {

--- a/test/BlockCipher/OpensslAeadTest.php
+++ b/test/BlockCipher/OpensslAeadTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-crypt for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Crypt\BlockCipher;
+
+use Zend\Crypt\Symmetric\Openssl;
+use Zend\Crypt\BlockCipher;
+use Zend\Math\Rand;
+
+class OpensslAeadTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $openssl = new Openssl();
+        if (! $openssl->isAuthEncAvailable()) {
+            $this->markTestSkipped('Authenticated encryption is not available on this platform');
+        }
+        $this->blockCipher = new BlockCipher($openssl);
+    }
+
+    public function getAuthEncryptionMode()
+    {
+        return [
+            [ 'gcm' ],
+            [ 'ccm' ]
+        ];
+    }
+
+    /**
+     * @dataProvider getAuthEncryptionMode
+     */
+    public function testEncryptDecrypt($mode)
+    {
+        $this->blockCipher->getCipher()->setMode($mode);
+        $this->blockCipher->setKey('test');
+        $plaintext = Rand::getBytes(1024);
+        $ciphertext = $this->blockCipher->encrypt($plaintext);
+        $this->assertEquals($plaintext, $this->blockCipher->decrypt($ciphertext));
+    }
+}

--- a/test/FileCipher/CompatibilityTest.php
+++ b/test/FileCipher/CompatibilityTest.php
@@ -19,7 +19,10 @@ class CompatibilityTest extends TestCase
 {
     public function setUp()
     {
-        if (! extension_loaded('mcrypt') || ! extension_loaded('mcrypt')) {
+        if (PHP_VERSION_ID >= 70100) {
+            $this->markTestSkipped('The Mcrypt tests are deprecated for PHP 7.1+');
+        }
+        if (! extension_loaded('mcrypt') || ! extension_loaded('openssl')) {
             $this->markTestSkipped(
                 sprintf("I cannot execute %s without Mcrypt and OpenSSL installed", __CLASS__)
             );

--- a/test/FileCipher/McryptTest.php
+++ b/test/FileCipher/McryptTest.php
@@ -17,6 +17,9 @@ class McryptTest extends AbstractFileCipherTest
 {
     public function setUp()
     {
+        if (PHP_VERSION_ID >= 70100) {
+            $this->markTestSkipped('The Mcrypt tests are deprecated for PHP 7.1+');
+        }
         try {
             $this->fileCipher = new FileCipher(new Mcrypt);
         } catch (Symmetric\Exception\RuntimeException $e) {

--- a/test/PublicKey/DiffieHellmanTest.php
+++ b/test/PublicKey/DiffieHellmanTest.php
@@ -239,4 +239,58 @@ class DiffieHellmanTest extends \PHPUnit_Framework_TestCase
         new DiffieHellman('563', '5', '9', DiffieHellman::FORMAT_NUMBER);
         new DiffieHellman('563', '5', hex2bin('09'), DiffieHellman::FORMAT_BINARY);
     }
+
+    /**
+     * @expectedException Zend\Crypt\Exception\InvalidArgumentException
+     */
+    public function testGetPublicKeyWithoutGenerated()
+    {
+        $dh = new DiffieHellman(563, 5);
+        $pubKey = $dh->getPublicKey();
+    }
+
+    /**
+     * @expectedException Zend\Crypt\Exception\InvalidArgumentException
+     */
+    public function testSetWrongPublicKey()
+    {
+        $dh = new DiffieHellman(563, 5);
+        $dh->setPublicKey(-2);
+    }
+
+    /**
+     * @expectedException Zend\Crypt\Exception\InvalidArgumentException
+     */
+    public function testGetSharedSecretKeyWihoutCompute()
+    {
+        $dh = new DiffieHellman(563, 5);
+        $skey = $dh->getSharedSecretKey();
+    }
+
+    /**
+     * @expectedException Zend\Crypt\Exception\InvalidArgumentException
+     */
+    public function testSetWrongPrime()
+    {
+        $dh = new DiffieHellman(563, 5);
+        $dh->setPrime(-2);
+    }
+
+    /**
+     * @expectedException Zend\Crypt\Exception\InvalidArgumentException
+     */
+    public function testSetWrongGenerator()
+    {
+        $dh = new DiffieHellman(563, 5);
+        $dh->setGenerator(-2);
+    }
+
+    /**
+     * @expectedException Zend\Crypt\Exception\InvalidArgumentException
+     */
+    public function testSetWrongPrivateKey()
+    {
+        $dh = new DiffieHellman(563, 5);
+        $privKey = $dh->setPrivateKey(-2);
+    }
 }

--- a/test/Symmetric/AbstractTest.php
+++ b/test/Symmetric/AbstractTest.php
@@ -199,7 +199,12 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
         foreach ($this->crypt->getSupportedAlgorithms() as $algo) {
             foreach ($this->crypt->getSupportedModes() as $mode) {
                 $this->crypt->setAlgorithm($algo);
-                $this->crypt->setMode($mode);
+                try {
+                    $this->crypt->setMode($mode);
+                } catch (\Exception $e) {
+                    // Continue if the encryption mode is not supported for the algorithm
+                    continue;
+                }
                 $this->crypt->setKey($this->generateKey());
                 if ($this->crypt->getSaltSize() > 0) {
                     $this->crypt->setSalt($this->generateSalt());

--- a/test/Symmetric/AbstractTest.php
+++ b/test/Symmetric/AbstractTest.php
@@ -291,6 +291,26 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(ContainerInterface::class, $this->crypt->getPaddingPluginManager());
     }
 
+    /**
+     * @expectedException Zend\Crypt\Symmetric\Exception\InvalidArgumentException
+     */
+    public function testSetWrongPaddingPluginManager()
+    {
+        $this->crypt->setPaddingPluginManager(
+            stdClass::class
+        );
+    }
+
+    /**
+     * @expectedException Zend\Crypt\Symmetric\Exception\InvalidArgumentException
+     */
+    public function testSetNotExistingPaddingPluginManager()
+    {
+        $this->crypt->setPaddingPluginManager(
+            'Foo'
+        );
+    }
+
     protected function generateKey()
     {
         return Rand::getBytes($this->crypt->getKeySize());

--- a/test/Symmetric/CompatibilityTest.php
+++ b/test/Symmetric/CompatibilityTest.php
@@ -19,7 +19,10 @@ class CompatibilityTest extends TestCase
 
     public function setUp()
     {
-        if (! extension_loaded('mcrypt') || ! extension_loaded('mcrypt')) {
+        if (PHP_VERSION_ID >= 70100) {
+            $this->markTestSkipped('The Mcrypt tests are deprecated for PHP 7.1+');
+        }
+        if (! extension_loaded('mcrypt') || ! extension_loaded('openssl')) {
             $this->markTestSkipped(
                 sprintf("I cannot execute %s without Mcrypt and OpenSSL installed", __CLASS__)
             );

--- a/test/Symmetric/McryptDeprecatedTest.php
+++ b/test/Symmetric/McryptDeprecatedTest.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-crypt for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Crypt\Symmetric;
+
+use Zend\Crypt\Symmetric\Mcrypt;
+
+class MCryptDeprecatedTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        if (PHP_VERSION_ID < 70100) {
+            $this->markTestSkipped('The Mcrypt deprecated test is for PHP 7.1+');
+        }
+    }
+
+    /**
+     * @expectedException PHPUnit_Framework_Error_Deprecated
+     */
+    public function testDeprecated()
+    {
+        $mcrypt = new Mcrypt();
+    }
+}

--- a/test/Symmetric/McryptTest.php
+++ b/test/Symmetric/McryptTest.php
@@ -25,6 +25,14 @@ class McryptTest extends AbstractTest
 
     protected $default_padding = 'pkcs7';
 
+    public function setUp()
+    {
+        if (PHP_VERSION_ID >= 70100) {
+            $this->markTestSkipped('The Mcrypt tests are deprecated for PHP 7.1+');
+        }
+        parent::setUp();
+    }
+
     public function testSetShortKey()
     {
         foreach ($this->crypt->getSupportedAlgorithms() as $algo) {

--- a/test/Symmetric/OpensslAeadTest.php
+++ b/test/Symmetric/OpensslAeadTest.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Crypt\Symmetric;
+
+use Zend\Crypt\Symmetric\Openssl;
+use Zend\Math\Rand;
+
+/**
+ *
+ * This is a set of unit tests for OpenSSL Authenticated Encrypt with Associated Data (AEAD)
+ * support from PHP 7.1+
+ */
+class OpensslAeadTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->crypt = new Openssl();
+        if (! $this->crypt->isAuthEncAvailable()) {
+            $this->markTestSkipped('Authenticated encryption is not available on this platform');
+        }
+    }
+
+    public function testSetGetAad()
+    {
+        $this->crypt->setMode('gcm');
+        $this->crypt->setAad('foo@bar.com');
+        $this->assertEquals('foo@bar.com', $this->crypt->getAad());
+    }
+
+    /**
+     * @expectedException Zend\Crypt\Symmetric\Exception\RuntimeException
+     */
+    public function testSetAadException()
+    {
+        $this->crypt->setMode('cbc');
+        $this->crypt->setAad('foo@bar.com');
+    }
+
+    public function testSetGetGcmTagSize()
+    {
+        $this->crypt->setMode('gcm');
+        $this->crypt->setTagSize(10);
+        $this->assertEquals(10, $this->crypt->getTagSize());
+    }
+
+    public function testSetGetCcmTagSize()
+    {
+        $this->crypt->setMode('ccm');
+        $this->crypt->setTagSize(28);
+        $this->assertEquals(28, $this->crypt->getTagSize());
+    }
+
+    /**
+     * @expectedException Zend\Crypt\Symmetric\Exception\RuntimeException
+     */
+    public function testSetTagSizeException()
+    {
+        $this->crypt->setMode('cbc');
+        $this->crypt->setTagSize(10);
+    }
+
+    /**
+     * @expectedException Zend\Crypt\Symmetric\Exception\InvalidArgumentException
+     */
+    public function testSetInvalidGcmTagSize()
+    {
+        $this->crypt->setMode('gcm');
+        $this->crypt->setTagSize(18); // gcm supports tag size between 4 and 16
+    }
+
+    public function getAuthEncryptionMode()
+    {
+        return [
+            [ 'gcm' ],
+            [ 'ccm' ]
+        ];
+    }
+
+    /**
+     * @dataProvider getAuthEncryptionMode
+     */
+    public function testAuthenticatedEncryption($mode)
+    {
+        $this->crypt->setMode($mode);
+        $this->crypt->setKey(random_bytes($this->crypt->getKeySize()));
+        $this->crypt->setSalt(random_bytes($this->crypt->getSaltSize()));
+
+        $plaintext = Rand::getBytes(1024);
+        $encrypt = $this->crypt->encrypt($plaintext);
+        $tag = $this->crypt->getTag();
+
+        $this->assertEquals($this->crypt->getTagSize(), strlen($tag));
+        $this->assertEquals(mb_substr($encrypt, 0, $this->crypt->getTagSize(), '8bit'), $tag);
+
+        $decrypt = $this->crypt->decrypt($encrypt);
+        $tag2 = $this->crypt->getTag();
+        $this->assertEquals($tag, $tag2);
+        $this->assertEquals($plaintext, $decrypt);
+    }
+
+    /**
+     * @dataProvider getAuthEncryptionMode
+     * @expectedException Zend\Crypt\Symmetric\Exception\RuntimeException
+     */
+    public function testAuthenticationError($mode)
+    {
+        $this->crypt->setMode($mode);
+        $this->crypt->setKey(random_bytes($this->crypt->getKeySize()));
+        $this->crypt->setSalt(random_bytes($this->crypt->getSaltSize()));
+
+        $plaintext = Rand::getBytes(1024);
+        $encrypt = $this->crypt->encrypt($plaintext);
+
+        // Alter the encrypted message
+        $i = rand(0, mb_strlen($encrypt, '8bit') - 1);
+        $encrypt[$i] = $encrypt[$i] ^ chr(1);
+
+        $decrypt = $this->crypt->decrypt($encrypt);
+    }
+
+    public function testGcmEncryptWithTagSize()
+    {
+        $this->crypt->setMode('gcm');
+        $this->crypt->setKey(random_bytes($this->crypt->getKeySize()));
+        $this->crypt->setSalt(random_bytes($this->crypt->getSaltSize()));
+        $this->crypt->setTagSize(14);
+
+        $plaintext = Rand::getBytes(1024);
+        $encrypt = $this->crypt->encrypt($plaintext);
+        $this->assertEquals(14, $this->crypt->getTagSize());
+        $this->assertEquals($this->crypt->getTagSize(), strlen($this->crypt->getTag()));
+    }
+
+    public function testCcmEncryptWithTagSize()
+    {
+        $this->crypt->setMode('ccm');
+        $this->crypt->setKey(random_bytes($this->crypt->getKeySize()));
+        $this->crypt->setSalt(random_bytes($this->crypt->getSaltSize()));
+        $this->crypt->setTagSize(24);
+
+        $plaintext = Rand::getBytes(1024);
+        $encrypt = $this->crypt->encrypt($plaintext);
+        $this->assertEquals(24, $this->crypt->getTagSize());
+        $this->assertEquals($this->crypt->getTagSize(), strlen($this->crypt->getTag()));
+    }
+
+    /**
+     * @dataProvider getAuthEncryptionMode
+     */
+    public function testAuthenticatedEncryptionWithAdditionalData($mode)
+    {
+        $this->crypt->setMode($mode);
+        $this->crypt->setKey(random_bytes($this->crypt->getKeySize()));
+        $this->crypt->setSalt(random_bytes($this->crypt->getSaltSize()));
+        $this->crypt->setAad('foo@bar.com');
+
+        $plaintext = Rand::getBytes(1024);
+        $encrypt = $this->crypt->encrypt($plaintext);
+        $tag = $this->crypt->getTag();
+
+        $this->assertEquals($this->crypt->getTagSize(), strlen($tag));
+        $this->assertEquals(mb_substr($encrypt, 0, $this->crypt->getTagSize(), '8bit'), $tag);
+
+        $decrypt = $this->crypt->decrypt($encrypt);
+        $tag2 = $this->crypt->getTag();
+        $this->assertEquals($tag, $tag2);
+        $this->assertEquals($plaintext, $decrypt);
+    }
+
+    /**
+     * @dataProvider getAuthEncryptionMode
+     * @expectedException Zend\Crypt\Symmetric\Exception\RuntimeException
+     */
+    public function testAuthenticationErrorOnAdditionalData($mode)
+    {
+        $this->crypt->setMode($mode);
+        $this->crypt->setKey(random_bytes($this->crypt->getKeySize()));
+        $this->crypt->setSalt(random_bytes($this->crypt->getSaltSize()));
+        $this->crypt->setAad('foo@bar.com');
+
+        $plaintext = Rand::getBytes(1024);
+        $encrypt = $this->crypt->encrypt($plaintext);
+
+        // Alter the additional authentication data
+        $this->crypt->setAad('foo@baz.com');
+        $decrypt = $this->crypt->decrypt($encrypt);
+    }
+}

--- a/test/Symmetric/OpensslAeadTest.php
+++ b/test/Symmetric/OpensslAeadTest.php
@@ -27,6 +27,22 @@ class OpensslAeadTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testConstructByParams()
+    {
+        $params = [
+            'algo'     => 'aes',
+            'mode'     => 'gcm',
+            'aad'      => 'foo@bar.com',
+            'tag_size' => 14
+        ];
+        $crypt = new Openssl($params);
+
+        $this->assertEquals($params['algo'], $crypt->getAlgorithm());
+        $this->assertEquals($params['mode'], $crypt->getMode());
+        $this->assertEquals($params['aad'], $crypt->getAad());
+        $this->assertEquals($params['tag_size'], $crypt->getTagSize());
+    }
+
     public function testSetGetAad()
     {
         $this->crypt->setMode('gcm');

--- a/test/Symmetric/OpensslAeadTest.php
+++ b/test/Symmetric/OpensslAeadTest.php
@@ -112,7 +112,7 @@ class OpensslAeadTest extends \PHPUnit_Framework_TestCase
         $encrypt = $this->crypt->encrypt($plaintext);
         $tag = $this->crypt->getTag();
 
-        $this->assertEquals($this->crypt->getTagSize(), strlen($tag));
+        $this->assertEquals($this->crypt->getTagSize(), mb_strlen($tag, '8bit'));
         $this->assertEquals(mb_substr($encrypt, 0, $this->crypt->getTagSize(), '8bit'), $tag);
 
         $decrypt = $this->crypt->decrypt($encrypt);
@@ -151,7 +151,7 @@ class OpensslAeadTest extends \PHPUnit_Framework_TestCase
         $plaintext = Rand::getBytes(1024);
         $encrypt = $this->crypt->encrypt($plaintext);
         $this->assertEquals(14, $this->crypt->getTagSize());
-        $this->assertEquals($this->crypt->getTagSize(), strlen($this->crypt->getTag()));
+        $this->assertEquals($this->crypt->getTagSize(), mb_strlen($this->crypt->getTag(), '8bit'));
     }
 
     public function testCcmEncryptWithTagSize()
@@ -164,7 +164,7 @@ class OpensslAeadTest extends \PHPUnit_Framework_TestCase
         $plaintext = Rand::getBytes(1024);
         $encrypt = $this->crypt->encrypt($plaintext);
         $this->assertEquals(24, $this->crypt->getTagSize());
-        $this->assertEquals($this->crypt->getTagSize(), strlen($this->crypt->getTag()));
+        $this->assertEquals($this->crypt->getTagSize(), mb_strlen($this->crypt->getTag(), '8bit'));
     }
 
     /**
@@ -181,7 +181,7 @@ class OpensslAeadTest extends \PHPUnit_Framework_TestCase
         $encrypt = $this->crypt->encrypt($plaintext);
         $tag = $this->crypt->getTag();
 
-        $this->assertEquals($this->crypt->getTagSize(), strlen($tag));
+        $this->assertEquals($this->crypt->getTagSize(), mb_strlen($tag, '8bit'));
         $this->assertEquals(mb_substr($encrypt, 0, $this->crypt->getTagSize(), '8bit'), $tag);
 
         $decrypt = $this->crypt->decrypt($encrypt);

--- a/test/SymmetricPluginManagerTest.php
+++ b/test/SymmetricPluginManagerTest.php
@@ -18,6 +18,11 @@ class SymmetricPluginManagerTest extends \PHPUnit_Framework_TestCase
 {
     public function getSymmetrics()
     {
+        if (PHP_VERSION_ID >= 70100) {
+            return [
+              [ 'openssl' ]
+            ];
+        }
         return [
             [ 'mcrypt' ],
             [ 'openssl' ],


### PR DESCRIPTION
This PR adds the GCM and CCM authenticated encryption mode for OpenSSL for PHP 7.1. This is a new feature of PHP 7.1 proposed in [PHP RFC: OpenSSL AEAD support](https://wiki.php.net/rfc/openssl_aead).
Read [this blog post](http://www.zimuel.it/authenticated-encrypt-with-openssl-and-php-7-1/) for more information about the usage of these encryption modes in PHP.
I've updated the `Zend\Crypt\BlockCipher` documentation for this new feature.

**Note:** I opened this bug [#73478](https://bugs.php.net/bug.php?id=73478) on bugs.php.net. I fixed the zend-crypt code to prevent this issue.