### PR TITLE
Update Openssl.php

### DIFF
--- a/src/Symmetric/Openssl.php
+++ b/src/Symmetric/Openssl.php
@@ -90,6 +90,7 @@ class Openssl implements SymmetricInterface
         'cfb',
         'ofb',
         'ecb',
+        'ctr',
     ];
 
     /**


### PR DESCRIPTION
Added "ctr" to the list of supported modes.  On most openssl installations this is only supported for AES.  setMode() is already configured to check to see if this mode is supported on the user's server and will throw an InvalidArgumentException if the user attempts to use counter mode with an algorithm which does not support it.