### PR TITLE
spelling fixes

### DIFF
--- a/doc/book/password.md
+++ b/doc/book/password.md
@@ -126,7 +126,7 @@ $bcrypt = new Bcrypt([
   the AuthName directive in `httpd.conf`.
 
 In order to specify the format of the Apache’s password, use the `setFormat()`
-method. An example with all the formats usage is demostrated below:
+method. An example with all the formats usage is demonstrated below:
 
 ```php
 use Zend\Crypt\Password\Apache;

--- a/src/FileCipher.php
+++ b/src/FileCipher.php
@@ -361,7 +361,7 @@ class FileCipher
     }
 
     /**
-     * Check that input file exists and output file dont
+     * Check that input file exists and output file don't
      *
      * @param  string $fileIn
      * @param  string $fileOut


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.