### PR TITLE
Fix incorrect type declaration in Hybrid constructor

### DIFF
--- a/src/Hybrid.php
+++ b/src/Hybrid.php
@@ -29,17 +29,17 @@ class Hybrid
     protected $bCipher;
 
     /**
-     * @var Rsa
+     * @var PublicKey\Rsa
      */
     protected $rsa;
 
     /**
      * Constructor
      *
-     * @param BlockCipher $blockCipher
-     * @param Rsa $public
+     * @param BlockCipher $bCipher
+     * @param PublicKey\Rsa $rsa
      */
-    public function __construct(BlockCipher $bCipher = null, Rsa $rsa = null)
+    public function __construct(BlockCipher $bCipher = null, PublicKey\Rsa $rsa = null)
     {
         $this->bCipher = (null === $bCipher ) ? BlockCipher::factory('openssl') : $bCipher;
         $this->rsa     = (null === $rsa ) ? new PublicKey\Rsa() : $rsa;

--- a/test/HybridTest.php
+++ b/test/HybridTest.php
@@ -32,6 +32,15 @@ class HybridTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Hybrid::class, $hybrid);
     }
 
+    public function testConstructorWithParameters()
+    {
+        $hybrid = new Hybrid(
+            $this->prophesize(BlockCipher::class)->reveal(),
+            $this->prophesize(Rsa::class)->reveal()
+        );
+        $this->assertInstanceOf(Hybrid::class, $hybrid);
+    }
+
     public function testGetDefaultBlockCipherInstance()
     {
         $bCipher = $this->hybrid->getBlockCipherInstance();


### PR DESCRIPTION
The type declaration in the Hybrid class' constructor required `Zend\Crypt\Rsa` as its second parameter, which doesn't exist.

I've changed it to `Zend\Crypt\PublicKey\Rsa`, which is the expected type.

I've also added unit test for it.